### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
     "mongoose": "^8.16.4",
-    "morgan": "^1.10.1"
+    "morgan": "^1.10.1",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -3,6 +3,14 @@ const router = express.Router();
 const { body } = require('express-validator');
 const validateRequest = require('../middlewares/validateRequest');
 const ctrl = require('../controllers/orderController');
+const rateLimit = require('express-rate-limit');
+
+// Apply rate limiting to DELETE requests (e.g., max 10 per minute per IP)
+const deleteLimiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 10, // limit each IP to 10 delete requests per windowMs
+    message: "Too many delete requests from this IP, please try again later."
+});
 
 router.get('/', ctrl.getAll);
 router.get('/:id', ctrl.getOne);
@@ -18,6 +26,6 @@ router.post(
     ctrl.create
 );
 router.put('/:id', ctrl.update);
-router.delete('/:id', ctrl.remove);
+router.delete('/:id', deleteLimiter, ctrl.remove);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/shivam-verma-19/wms-api/security/code-scanning/10](https://github.com/shivam-verma-19/wms-api/security/code-scanning/10)

To fix the missing rate limiting issue, we should add a rate limiting middleware to the DELETE route (and, ideally, to other sensitive routes as well). The most straightforward solution is to use the well-known `express-rate-limit` package. We should import this package, configure a rate limiter (for example, allowing a reasonable number of requests per time window), and apply it as middleware to the DELETE route. This involves adding an import for `express-rate-limit`, creating a rate limiter instance, and adding it to the middleware chain for the `router.delete('/:id', ...)` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
