### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/routes/inventoryRoutes.js
+++ b/routes/inventoryRoutes.js
@@ -1,11 +1,18 @@
 const express = require('express');
 const router = express.Router();
+const RateLimit = require('express-rate-limit');
 const { body } = require('express-validator');
 const validateRequest = require('../middlewares/validateRequest');
 const ctrl = require('../controllers/inventoryController');
 
+// Set up rate limiter: max 100 requests per 15 minutes per IP
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
 router.get('/', ctrl.getAll);
-router.get('/:id', ctrl.getOne);
+router.get('/:id', limiter, ctrl.getOne);
 router.post(
     '/',
     [


### PR DESCRIPTION
Potential fix for [https://github.com/shivam-verma-19/wms-api/security/code-scanning/5](https://github.com/shivam-verma-19/wms-api/security/code-scanning/5)

The best way to fix this issue is to add a rate-limiting middleware to the router or to the specific route in question. The common practice is to use the widely-adopted `express-rate-limit` package for this purpose. The fix involves:

- Importing `express-rate-limit` at the top of the file.
- Defining a suitable rate limiter instance (e.g., 100 requests per 15 minutes).
- Applying the rate limiter to the router or specifically to the `/inventory/:id` GET route.

To avoid changing existing functionality, it's safest to apply the rate limiter only to the route(s) flagged as problematic (e.g., `router.get('/:id', ...)`). This involves inserting the rate limiter in the middleware chain for the affected route.

Required changes:
- Add an import for `express-rate-limit`.
- Define a rate limiter instance.
- Add the `limiter` middleware to the `router.get('/:id', ...)` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
