### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/routes/inventoryRoutes.js
+++ b/routes/inventoryRoutes.js
@@ -3,6 +3,14 @@ const router = express.Router();
 const { body } = require('express-validator');
 const validateRequest = require('../middlewares/validateRequest');
 const ctrl = require('../controllers/inventoryController');
+const rateLimit = require('express-rate-limit');
+
+// Configure a rate limiter for delete requests (e.g., 10 requests per minute per IP)
+const deleteLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 10, // limit each IP to 10 requests per windowMs
+    message: 'Too many delete requests from this IP, please try again after a minute'
+});
 
 router.get('/', ctrl.getAll);
 router.get('/:id', ctrl.getOne);
@@ -18,6 +26,6 @@ router.post(
     ctrl.create
 );
 router.put('/:id', ctrl.update);
-router.delete('/:id', ctrl.remove);
+router.delete('/:id', deleteLimiter, ctrl.remove);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/shivam-verma-19/wms-api/security/code-scanning/7](https://github.com/shivam-verma-19/wms-api/security/code-scanning/7)

To fix the missing rate limiting on the potentially expensive `DELETE /:id` route, a rate-limiting middleware should be applied to this route. The best practice is to use a standard package such as `express-rate-limit` to limit the number of requests a single client can make to this route within a certain time window. This can be done by creating a rate limiter instance and applying it specifically to the `DELETE /:id` route in `routes/inventoryRoutes.js`. Only the relevant route needs to be updated; the rest of the application's routes can remain unaffected, unless broader coverage is desired.

The following changes are needed:
- Import the `express-rate-limit` package at the top of the file.
- Define a rate limiter instance (e.g., maximum 10 deletes per minute per IP).
- Apply this middleware to the `router.delete('/:id', ...)` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
