### PR TITLE
Potential fix for code scanning alert no. 16: Missing rate limiting

### DIFF
--- a/routes/inventoryRoutes.js
+++ b/routes/inventoryRoutes.js
@@ -32,7 +32,7 @@ router.post(
     validateRequest,
     ctrl.create
 );
-router.put('/:id', ctrl.update);
+router.put('/:id', limiter, ctrl.update);
 router.delete('/:id', deleteLimiter, ctrl.remove);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/shivam-verma-19/wms-api/security/code-scanning/16](https://github.com/shivam-verma-19/wms-api/security/code-scanning/16)

To fix this issue, a rate-limiting middleware needs to be applied to the `update` route handler to prevent abuse. This can be achieved by creating a rate limiter specifically for the `update` route or reusing the existing `limiter` middleware defined in the file. The rate limiter should restrict the number of requests an IP can make to the `update` endpoint within a specific time window.

Steps:
1. Add a rate limiter for the `update` route by either reusing the `limiter` (configured for 100 requests per 15 minutes) or defining a new limiter with specific parameters.
2. Apply the rate limiter middleware to the `update` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
